### PR TITLE
Test: separate_number_and_text and timestamp_to_date_string

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,3 +1,5 @@
+use crate::{separate_number_and_text, timestamp_to_date_string};
+
 /**
  * Test Nearblocks mocked transactions
  */
@@ -21,4 +23,37 @@ fn test_index() {
     // Dispatch a request to 'GET /' and validate the response.
     let response = client.get("/").dispatch();
     assert_eq!(response.into_string().unwrap(), "Welcome from fly.io!!!!!");
+}
+
+#[test]
+fn test_timestamp_to_date_string() {
+    // Test regular date
+    assert_eq!(timestamp_to_date_string(1704067200000000000), "2024-01-01");
+
+    // Test edge cases
+    assert_eq!(timestamp_to_date_string(0), "1970-01-01");
+
+    // Test negative timestamp
+    assert_eq!(timestamp_to_date_string(-86400000000000), "1969-12-31");
+}
+
+#[test]
+fn test_separate_number_and_text() {
+    // Test normal case
+    assert_eq!(
+        separate_number_and_text("123 test"),
+        (Some(123), "test".to_string())
+    );
+
+    // Test no number
+    assert_eq!(separate_number_and_text("test"), (None, "test".to_string()));
+
+    // Test only number
+    assert_eq!(separate_number_and_text("123"), (Some(123), "".to_string()));
+
+    // Test number at end
+    assert_eq!(
+        separate_number_and_text("test 123"),
+        (Some(123), "test".to_string())
+    );
 }


### PR DESCRIPTION
Added
1. test_timestamp_to_date_string
2. test_separate_number_and_text