### PR TITLE
Cronjob to synchronize with just the RPC and without Nearblocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 devhub.near*
 events-committee.near*
 infrastructure-committee.near*
+/tmp
+archival-response-decoder.js

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 near-workspaces = { version = "0.16.0", optional = true }
 near-account-id = "1.0.0"
-near-sdk = "5.3.0"
+near-sdk = "5.7.0"
 rocket = { version = "0.5.0", features = ['json'] }
 tokio = { version = "1.4", features = ["full"] }
 rocket_db_pools = { version = "0.2.0", features = ['sqlx_postgres', 'sqlx'] }

--- a/src/entrypoints/proposal/mod.rs
+++ b/src/entrypoints/proposal/mod.rs
@@ -115,6 +115,70 @@ async fn get_proposals(
     )))
 }
 
+#[get("/sync")]
+async fn sync_proposals(
+    db: &State<DB>,
+    contract: &State<AccountId>,
+) -> Result<Json<Vec<i32>>, Status> {
+    let rpc_service = RpcService::new(contract);
+    let proposal_ids = match rpc_service.get_all_proposal_ids().await {
+        Ok(proposal_ids) => proposal_ids,
+        Err(e) => {
+            eprintln!("Failed to get proposal ids: {:?}", e);
+            return Err(Status::InternalServerError);
+        }
+    };
+
+    let last_ten_proposal_ids = proposal_ids
+        .iter()
+        .rev()
+        .take(20)
+        .copied()
+        .collect::<Vec<_>>();
+
+    let mut tx = db.begin().await.map_err(|e| {
+        eprintln!("Failed to begin transaction: {:?}", e);
+        Status::InternalServerError
+    })?;
+
+    for proposal_id in last_ten_proposal_ids.clone() {
+        println!("syncing proposal_id: {}", proposal_id);
+        let proposal = rpc_service.get_proposal(proposal_id).await.unwrap();
+        let block_timestamp = rpc_service
+            .block_timestamp(proposal.block_height)
+            .await
+            .unwrap();
+
+        let snapshot = ProposalSnapshotRecord::from_contract_proposal(
+            proposal.data.into(),
+            block_timestamp as i64,
+            proposal.block_height as i64,
+        );
+
+        DB::upsert_proposal(
+            &mut tx,
+            snapshot.proposal_id as u32,
+            snapshot.editor_id.to_string(),
+        )
+        .await
+        .map_err(|e| {
+            eprintln!(
+                "Failed to upsert proposal {}: {:?}",
+                snapshot.proposal_id, e
+            );
+            Status::InternalServerError
+        })?;
+        let _ = DB::insert_proposal_snapshot(&mut tx, &snapshot).await;
+    }
+
+    tx.commit().await.map_err(|e| {
+        eprintln!("Failed to commit transaction: {:?}", e);
+        Status::InternalServerError
+    })?;
+
+    Ok(Json(last_ten_proposal_ids))
+}
+
 #[utoipa::path(get, path = "/proposal/{proposal_id}/snapshots")]
 #[get("/<proposal_id>/snapshots")]
 async fn get_proposal_with_all_snapshots(
@@ -264,6 +328,7 @@ pub fn stage() -> rocket::fairing::AdHoc {
                     reset,
                     set_cursor,
                     set_block,
+                    sync_proposals,
                 ],
             )
             .mount(

--- a/src/entrypoints/rfp/mod.rs
+++ b/src/entrypoints/rfp/mod.rs
@@ -66,6 +66,56 @@ async fn fetch_rfps(
     }
 }
 
+#[get("/sync")]
+async fn sync_rfps(db: &State<DB>, contract: &State<AccountId>) -> Result<Json<Vec<i32>>, Status> {
+    let rpc_service = RpcService::new(contract);
+    let rfp_ids = match rpc_service.get_all_rfp_ids().await {
+        Ok(rfp_ids) => rfp_ids,
+        Err(e) => {
+            eprintln!("Failed to get rfp ids: {:?}", e);
+            return Err(Status::InternalServerError);
+        }
+    };
+
+    let last_ten_rfp_ids = rfp_ids.iter().rev().take(10).copied().collect::<Vec<_>>();
+
+    let mut tx = db.begin().await.map_err(|e| {
+        eprintln!("Failed to begin transaction: {:?}", e);
+        Status::InternalServerError
+    })?;
+
+    for rfp_id in last_ten_rfp_ids.clone() {
+        println!("syncing rfp_id: {}", rfp_id);
+        let rfp = rpc_service.get_rfp(rfp_id).await.unwrap();
+        let block_timestamp = rpc_service.block_timestamp(rfp.block_height).await.unwrap();
+
+        let snapshot = RfpSnapshotRecord::from_contract_rfp(
+            rfp.data.into(),
+            block_timestamp as i64,
+            rfp.block_height as i64,
+        );
+
+        DB::upsert_rfp(
+            &mut tx,
+            snapshot.rfp_id as u32,
+            snapshot.editor_id.to_string(),
+        )
+        .await
+        .map_err(|e| {
+            eprintln!("Failed to upsert rfp {}: {:?}", snapshot.rfp_id, e);
+            Status::InternalServerError
+        })?;
+        let _ = DB::insert_rfp_snapshot(&mut tx, &snapshot).await;
+    }
+
+    tx.commit().await.map_err(|e| {
+        eprintln!("Failed to commit transaction: {:?}", e);
+        Status::InternalServerError
+    })?;
+
+    Ok(Json(last_ten_rfp_ids))
+}
+
 #[utoipa::path(get, path = "/rfps?<order>&<limit>&<offset>&<filters>", params(
   ("order"= &str, Path, description ="default order id_desc"),
   ("limit"= i64, Path, description = "default limit 10"),
@@ -173,7 +223,7 @@ pub fn stage() -> rocket::fairing::AdHoc {
         println!("Rfp stage on ignite!");
 
         rocket
-            .mount("/rfps/", rocket::routes![get_rfps, search])
+            .mount("/rfps/", rocket::routes![get_rfps, search, sync_rfps])
             .mount(
                 "/rfp/",
                 rocket::routes![

--- a/src/periodic_updater.rs
+++ b/src/periodic_updater.rs
@@ -1,0 +1,200 @@
+use crate::db::db_types::{ProposalSnapshotRecord, RfpSnapshotRecord};
+use crate::db::DB;
+use crate::entrypoints::proposal::proposal_types::FromContractProposal;
+use crate::entrypoints::rfp::rfp_types::FromContractRFP;
+use crate::rpc_service::RpcService;
+use near_account_id::AccountId;
+use rocket::{
+    fairing::{self, AdHoc, Fairing},
+    Build, Rocket,
+};
+use rocket_db_pools::Database;
+use std::time::Duration;
+use tokio::time::interval;
+
+pub struct PeriodicUpdater {
+    proposal_sync_interval: u64,
+    rfp_sync_interval: u64,
+}
+
+impl PeriodicUpdater {
+    // Helper function to sync proposals
+    pub async fn sync_proposals(db: &DB, contract: &AccountId) -> Result<Vec<i32>, String> {
+        let rpc_service = RpcService::new(contract);
+        let proposal_ids = match rpc_service.get_all_proposal_ids().await {
+            Ok(ids) => ids,
+            Err(e) => {
+                eprintln!("Failed to get proposal ids: {:?}", e);
+                return Err("Failed to get proposal ids".to_string());
+            }
+        };
+
+        let last_ten_proposal_ids = proposal_ids
+            .iter()
+            .rev()
+            .take(20)
+            .copied()
+            .collect::<Vec<_>>();
+
+        let mut tx = db.begin().await.map_err(|e| {
+            eprintln!("Failed to begin transaction: {:?}", e);
+            e.to_string()
+        })?;
+
+        for proposal_id in last_ten_proposal_ids.clone() {
+            println!("syncing proposal_id: {}", proposal_id);
+            let proposal = rpc_service.get_proposal(proposal_id).await.unwrap();
+            let block_timestamp = rpc_service
+                .block_timestamp(proposal.block_height)
+                .await
+                .unwrap();
+
+            let snapshot = ProposalSnapshotRecord::from_contract_proposal(
+                proposal.data.into(),
+                block_timestamp as i64,
+                proposal.block_height as i64,
+            );
+
+            DB::upsert_proposal(
+                &mut tx,
+                snapshot.proposal_id as u32,
+                snapshot.editor_id.to_string(),
+            )
+            .await
+            .map_err(|e| {
+                eprintln!(
+                    "Failed to upsert proposal {}: {:?}",
+                    snapshot.proposal_id, e
+                );
+                e.to_string()
+            })?;
+            let _ = DB::insert_proposal_snapshot(&mut tx, &snapshot).await;
+        }
+
+        tx.commit().await.map_err(|e| {
+            eprintln!("Failed to commit transaction: {:?}", e);
+            e.to_string()
+        })?;
+
+        Ok(last_ten_proposal_ids)
+    }
+
+    // Helper function to sync RFPs
+    pub async fn sync_rfps(db: &DB, contract: &AccountId) -> Result<Vec<i32>, String> {
+        let rpc_service = RpcService::new(contract);
+        let rfp_ids = match rpc_service.get_all_rfp_ids().await {
+            Ok(ids) => ids,
+            Err(e) => {
+                eprintln!("Failed to get rfp ids: {:?}", e);
+                return Err("Failed to get rfp ids".to_string());
+            }
+        };
+
+        let last_ten_rfp_ids = rfp_ids.iter().rev().take(10).copied().collect::<Vec<_>>();
+
+        let mut tx = db.begin().await.map_err(|e| {
+            eprintln!("Failed to begin transaction: {:?}", e);
+            e.to_string()
+        })?;
+
+        for rfp_id in last_ten_rfp_ids.clone() {
+            println!("syncing rfp_id: {}", rfp_id);
+            let rfp = rpc_service.get_rfp(rfp_id).await.unwrap();
+            let block_timestamp = rpc_service.block_timestamp(rfp.block_height).await.unwrap();
+
+            let snapshot = RfpSnapshotRecord::from_contract_rfp(
+                rfp.data.into(),
+                block_timestamp as i64,
+                rfp.block_height as i64,
+            );
+
+            DB::upsert_rfp(
+                &mut tx,
+                snapshot.rfp_id as u32,
+                snapshot.editor_id.to_string(),
+            )
+            .await
+            .map_err(|e| {
+                eprintln!("Failed to upsert rfp {}: {:?}", snapshot.rfp_id, e);
+                e.to_string()
+            })?;
+            let _ = DB::insert_rfp_snapshot(&mut tx, &snapshot).await;
+        }
+
+        tx.commit().await.map_err(|e| {
+            eprintln!("Failed to commit transaction: {:?}", e);
+            e.to_string()
+        })?;
+
+        Ok(last_ten_rfp_ids)
+    }
+}
+
+#[rocket::async_trait]
+impl Fairing for PeriodicUpdater {
+    fn info(&self) -> rocket::fairing::Info {
+        rocket::fairing::Info {
+            name: "Periodic Updater",
+            kind: rocket::fairing::Kind::Ignite,
+        }
+    }
+
+    async fn on_ignite(&self, rocket: Rocket<Build>) -> fairing::Result {
+        let db = match DB::fetch(&rocket) {
+            Some(db) => db,
+            None => return Err(rocket),
+        };
+
+        let contract = match rocket.state::<AccountId>() {
+            Some(contract) => contract.clone(),
+            None => return Err(rocket),
+        };
+
+        // Only spawn if proposal_sync_interval is greater than 0
+        if self.proposal_sync_interval > 0 {
+            let interval_duration = self.proposal_sync_interval;
+            let db_clone = db.clone();
+            let contract_clone = contract.clone();
+
+            tokio::spawn(async move {
+                let mut interval = interval(Duration::from_secs(interval_duration));
+                loop {
+                    interval.tick().await;
+                    println!("Running periodic update for Proposals...");
+                    if let Err(e) = Self::sync_proposals(&db_clone, &contract_clone).await {
+                        eprintln!("Error during proposal sync: {}", e);
+                    }
+                }
+            });
+        }
+
+        // Only spawn if rfp_sync_interval is greater than 0
+        if self.rfp_sync_interval > 0 {
+            let interval_duration = self.rfp_sync_interval;
+            let db_clone = db.clone();
+            let contract_clone = contract;
+
+            tokio::spawn(async move {
+                let mut interval = interval(Duration::from_secs(interval_duration));
+                loop {
+                    interval.tick().await;
+                    println!("Running periodic update for RFPs...");
+                    if let Err(e) = Self::sync_rfps(&db_clone, &contract_clone).await {
+                        eprintln!("Error during RFP sync: {}", e);
+                    }
+                }
+            });
+        }
+
+        Ok(rocket)
+    }
+}
+
+pub fn stage(proposal_sync_interval: u64, rfp_sync_interval: u64) -> AdHoc {
+    AdHoc::on_ignite("Periodic Updater Stage", move |rocket| async move {
+        rocket.attach(PeriodicUpdater {
+            proposal_sync_interval,
+            rfp_sync_interval,
+        })
+    })
+}

--- a/src/rpc_service.rs
+++ b/src/rpc_service.rs
@@ -86,6 +86,24 @@ impl RpcService {
         result
     }
 
+    pub async fn get_all_rfp_ids(&self) -> Result<Vec<i32>, Status> {
+        let result: Result<Data<Vec<i32>>, _> = self
+            .contract
+            .call_function("get_all_rfp_ids", ())
+            .unwrap()
+            .read_only()
+            .fetch_from(&self.network)
+            .await;
+
+        match result {
+            Ok(res) => Ok(res.data),
+            Err(e) => {
+                eprintln!("Failed to get all rfp ids: {:?}", e);
+                Err(Status::InternalServerError)
+            }
+        }
+    }
+
     pub async fn get_all_proposal_ids(&self) -> Result<Vec<i32>, Status> {
         let result: Result<Data<Vec<i32>>, _> = self
             .contract

--- a/src/rpc_service.rs
+++ b/src/rpc_service.rs
@@ -2,7 +2,7 @@ use devhub_shared::proposal::VersionedProposal;
 use devhub_shared::rfp::VersionedRFP;
 use near_account_id::AccountId;
 use near_api::{types::reference::Reference, types::Data};
-use near_api::{Contract, NetworkConfig, RPCEndpoint};
+use near_api::{Chain, Contract, NetworkConfig, RPCEndpoint};
 use near_jsonrpc_client::methods::query::RpcQueryRequest;
 use rocket::http::Status;
 use rocket::serde::json::json;
@@ -99,6 +99,21 @@ impl RpcService {
             Ok(res) => Ok(res.data),
             Err(e) => {
                 eprintln!("Failed to get all proposal ids: {:?}", e);
+                Err(Status::InternalServerError)
+            }
+        }
+    }
+
+    pub async fn block_timestamp(&self, block_id: u64) -> Result<u64, Status> {
+        let block = Chain::block()
+            .at(Reference::AtBlock(block_id))
+            .fetch_from(&self.network)
+            .await;
+
+        match block {
+            Ok(block) => Ok(block.header.timestamp),
+            Err(e) => {
+                eprintln!("Failed to get block timestamp: {:?}", e);
                 Err(Status::InternalServerError)
             }
         }


### PR DESCRIPTION
_Resolves [#1022](https://github.com/NEAR-DevHub/neardevhub-bos/issues/1022)_

Added code for a cronjob to scan for new rfp's and proposals based on two environment secrets:
1. `PROPOSAL_SYNC_INTERVAL`
2. `RFP_SYNC_INTERVAL`

If these secrets are not set it won't call the RPC.

Also added two endpoints for rfp and proposal to sync manually if an incident like this happens again, we can just quickly sync manually and than turn on the interval updates until any issues have been resolved.