### PR TITLE
don't update last processed block height on failure

### DIFF
--- a/src/nearblocks_client/transactions.rs
+++ b/src/nearblocks_client/transactions.rs
@@ -69,7 +69,9 @@ pub async fn update_nearblocks_data(
 
     println!("Total transactions fetched: {}", all_transactions.len());
 
-    if let Err(e) = nearblocks_client::transactions::process(&all_transactions, db.into(), contract).await {
+    if let Err(e) =
+        nearblocks_client::transactions::process(&all_transactions, db.into(), contract).await
+    {
         eprintln!("Error processing transactions: {:?}", e);
         return;
     }

--- a/src/nearblocks_client/transactions.rs
+++ b/src/nearblocks_client/transactions.rs
@@ -69,7 +69,10 @@ pub async fn update_nearblocks_data(
 
     println!("Total transactions fetched: {}", all_transactions.len());
 
-    let _ = nearblocks_client::transactions::process(&all_transactions, db.into(), contract).await;
+    if let Err(e) = nearblocks_client::transactions::process(&all_transactions, db.into(), contract).await {
+        eprintln!("Error processing transactions: {:?}", e);
+        return;
+    }
 
     if let Some(transaction) = all_transactions.last() {
         let timestamp_nano = transaction.block_timestamp.parse::<i64>().unwrap();

--- a/src/rpc_service.rs
+++ b/src/rpc_service.rs
@@ -49,6 +49,9 @@ impl RpcService {
         network.rpc_endpoints.push(RPCEndpoint::new(
             "https://free.rpc.fastnear.com".parse().unwrap(),
         ));
+        network.rpc_endpoints.push(RPCEndpoint::new(
+            "https://rpc.mainnet.fastnear.com".parse().unwrap(),
+        ));
 
         Self {
             network,


### PR DESCRIPTION
In the database there is a table named `last_updated_info` containing the block height from which to check for new data. Whenever new transactions are fetched from nearblocks, this table is updated with the block height of the latest transaction. The new transactions are analyzed and the database is updated with proposals data, but in case this fails, the `last_updated_info` is updated anyway.

This PR adds a check for if processing the transaction data failed, and if so, it will not update records in `last_updated_info`, which will also then lead to a retry of processing the transaction data when requested next time.

To fix existing proposals, that are not showing in the portals, just edit something on them. The `handle_set_block_height_callback` will upsert the proposal.

fixes #16 