### PR TITLE
Feat: switch to paid fastnear api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 devhub.near*
 events-committee.near*
 infrastructure-committee.near*
+/tmp
+archival-response-decoder.js


### PR DESCRIPTION
Moving to paid fastnear RPC, since we have bought the api key for the treasury board. This will stabilize it more, since the RPC is likely to run into 429 toomanyrequests error's.

> [!WARNING]  
> We need to add the api key to the env variable in all fly.io instances before merging / deploying.
