### PR TITLE
Improve sync from start

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -1,0 +1,18 @@
+# See https://fly.io/docs/app-guides/continuous-deployment-with-github-actions/
+
+name: Fly Deploy
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy:
+    name: Deploy app
+    runs-on: ubuntu-latest
+    concurrency: deploy-group    # optional: ensure only one action runs at a time
+    steps:
+      - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/bring-cache-up-to-date.py
+++ b/bring-cache-up-to-date.py
@@ -3,7 +3,7 @@ import requests
 
 local = False 
 reset_from_zero = False # False to continue from where it left off  
-fly_app_name = "devhub-cache-api-rs"
+fly_app_name = "devhub-cache-api-rs-2"
 # ~120 calls for devhub
 # ~20 calls for infra
 # ~40 calls for events

--- a/fly.events.toml
+++ b/fly.events.toml
@@ -1,24 +1,26 @@
-# fly.toml app configuration file generated for events-cache-api-rs on 2024-11-08T11:57:32+07:00
+# fly.toml app configuration file generated for events-cache-api-rs-2 on 2025-03-20T11:19:24-05:00
 #
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 #
 
-app = 'events-cache-api-rs'
+app = 'events-cache-api-rs-2'
 primary_region = 'ams'
 
+[build]
+
 [env]
-CONTRACT = 'events-committee.near'
-ROCKET_PROFILE = 'release'
+  CONTRACT = 'events-committee.near'
+  ROCKET_PROFILE = 'release'
 
 [http_service]
-internal_port = 8080
-force_https = true
-auto_stop_machines = 'stop'
-auto_start_machines = true
-min_machines_running = 0
-processes = ['app']
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ['app']
 
 [[vm]]
-memory = '1gb'
-cpu_kind = 'shared'
-cpus = 1
+  memory = '1gb'
+  cpu_kind = 'shared'
+  cpus = 1

--- a/fly.infra.toml
+++ b/fly.infra.toml
@@ -1,24 +1,26 @@
-# fly.toml app configuration file generated for infra-cache-api-rs on 2024-11-08T11:35:59+07:00
+# fly.toml app configuration file generated for infra-cache-api-rs-2 on 2025-03-20T11:02:28-05:00
 #
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 #
 
-app = 'infra-cache-api-rs'
+app = 'infra-cache-api-rs-2'
 primary_region = 'ams'
 
+[build]
+
 [env]
-CONTRACT = 'infrastructure-committee.near'
-ROCKET_PROFILE = 'release'
+  CONTRACT = 'infrastructure-committee.near'
+  ROCKET_PROFILE = 'release'
 
 [http_service]
-internal_port = 8080
-force_https = true
-auto_stop_machines = 'stop'
-auto_start_machines = true
-min_machines_running = 0
-processes = ['app']
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ['app']
 
 [[vm]]
-memory = '1gb'
-cpu_kind = 'shared'
-cpus = 1
+  memory = '1gb'
+  cpu_kind = 'shared'
+  cpus = 1

--- a/fly.templar.toml
+++ b/fly.templar.toml
@@ -1,24 +1,26 @@
-# fly.toml app configuration file generated for templar-cache-api-rs on 2024-11-12T16:52:11-08:00
+# fly.toml app configuration file generated for templar-cache-api-rs-2 on 2025-03-20T12:06:30-05:00
 #
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 #
 
-app = 'templar-cache-api-rs'
+app = 'templar-cache-api-rs-2'
 primary_region = 'ams'
 
+[build]
+
 [env]
-CONTRACT = 'treasury-templar.near'
-ROCKET_PROFILE = 'release'
+  CONTRACT = 'treasury-templar.near'
+  ROCKET_PROFILE = 'release'
 
 [http_service]
-internal_port = 8080
-force_https = true
-auto_stop_machines = 'stop'
-auto_start_machines = true
-min_machines_running = 0
-processes = ['app']
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ['app']
 
 [[vm]]
-memory = '1gb'
-cpu_kind = 'shared'
-cpus = 1
+  memory = '1gb'
+  cpu_kind = 'shared'
+  cpus = 1

--- a/fly.testing-indexer.toml
+++ b/fly.testing-indexer.toml
@@ -1,26 +1,26 @@
-# fly.toml app configuration file generated for testing-indexer on 2024-11-15T08:25:29-06:00
+# fly.toml app configuration file generated for testing-indexer-2 on 2025-03-20T10:45:30-05:00
 #
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 #
 
-app = 'testing-indexer'
+app = 'testing-indexer-2'
 primary_region = 'ams'
 
 [build]
 
 [env]
-CONTRACT = 'testing-indexer.near'
-ROCKET_PROFILE = 'release'
+  CONTRACT = 'testing-indexer.near'
+  ROCKET_PROFILE = 'release'
 
 [http_service]
-internal_port = 8080
-force_https = true
-auto_stop_machines = 'stop'
-auto_start_machines = true
-min_machines_running = 1
-processes = ['app']
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 1
+  processes = ['app']
 
 [[vm]]
-memory = '1gb'
-cpu_kind = 'shared'
-cpus = 1
+  memory = '1gb'
+  cpu_kind = 'shared'
+  cpus = 1

--- a/fly.toml
+++ b/fly.toml
@@ -1,10 +1,12 @@
-# fly.toml app configuration file generated for devhub-cache-api-rs on 2024-11-09T09:10:37+07:00
+# fly.toml app configuration file generated for devhub-cache-api-rs-2 on 2025-03-20T10:30:36-05:00
 #
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 #
-
-app = 'devhub-cache-api-rs'
+# org: devhub-128
+app = 'devhub-cache-api-rs-2'
 primary_region = 'ams'
+
+[build]
 
 [env]
 CONTRACT = 'devhub.near'

--- a/scripts/compare_cache_and_rpc.js
+++ b/scripts/compare_cache_and_rpc.js
@@ -169,7 +169,7 @@ const print_object_diff = (cache_obj, rpc_obj) => {
 const START_ID = 250;
 const END_ID = 260;
 const ARCHIVAL_RPC_URL = "https://archival-rpc.mainnet.near.org/";
-const CACHE_API_URL = "https://devhub-cache-api-rs.fly.dev/";
+const CACHE_API_URL = "https://devhub-cache-api-rs-2.fly.dev/";
 const SKIP_TIMELINE = true;
 
 const runComparisons = async () => {

--- a/scripts/compare_indexers.js
+++ b/scripts/compare_indexers.js
@@ -24,7 +24,7 @@ const fetch_from_pagoda = async () => {
 
 const fetch_from_cache = async () => {
   const response = await fetch(
-    `https://devhub-cache-api-rs.fly.dev/proposals?limit=${LIMIT}&offset=${OFFSET}`,
+    `https://devhub-cache-api-rs-2.fly.dev/proposals?limit=${LIMIT}&offset=${OFFSET}`,
     {
       method: "GET",
       headers: { "Content-Type": "application/json" },

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -123,6 +123,7 @@ impl DB {
         )
         .execute(&self.0)
         .await?;
+
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@ pub fn rocket(rpc_service: Option<RpcService>) -> rocket::Rocket<rocket::Build> 
     let contract: AccountId = env.contract.parse::<AccountId>().unwrap();
     let nearblocks_api_key = env.nearblocks_api_key;
 
-    let rpc_service = rpc_service.unwrap_or_default();
+    let rpc_service = rpc_service.unwrap_or(RpcService::mainnet(contract.clone()));
 
     rocket::custom(figment)
         .attach(cors)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,9 +102,9 @@ pub fn rocket(rpc_service: Option<RpcService>) -> rocket::Rocket<rocket::Build> 
         "https://devhub.near.page",
         "https://events-committee.near.page/",
         "https://infrastructure-committee.near.page/",
-        "https://devhub-cache-api-rs.fly.dev",
-        "https://infra-cache-api-rs.fly.dev",
-        "https://events-cache-api-rs.fly.dev",
+        "https://devhub-cache-api-rs-2.fly.dev",
+        "https://infra-cache-api-rs-2.fly.dev",
+        "https://events-cache-api-rs-2.fly.dev",
         // TODO Add prod urls here
     ]);
     let allowed_origins = Origins {

--- a/src/nearblocks_client/mod.rs
+++ b/src/nearblocks_client/mod.rs
@@ -72,7 +72,6 @@ impl ApiClient {
         }
 
         let response_text = response.text().await?;
-        println!("Response body: {}", response_text);
 
         match serde_json::from_str::<ApiResponse>(&response_text) {
             Ok(api_response) => {

--- a/src/rpc_service.rs
+++ b/src/rpc_service.rs
@@ -161,7 +161,7 @@ impl RpcService {
         &self,
         proposal_id: i32,
         block_id: i64,
-    ) -> Result<VersionedProposal, Status> {
+    ) -> anyhow::Result<VersionedProposal> {
         let result: Result<Data<VersionedProposal>, near_api::errors::QueryError<RpcQueryRequest>> =
             self.contract
                 .call_function("get_proposal", json!({ "proposal_id": proposal_id }))
@@ -182,7 +182,11 @@ impl RpcService {
                     );
                     eprintln!("{:?}", on_block_error);
                     eprintln!("{:?}", rpc_error);
-                    Err(Status::InternalServerError)
+                    Err(anyhow::anyhow!(
+                        "Failed to get proposal from RPC on block height {} and id {}",
+                        block_id,
+                        proposal_id
+                    ))
                 }
             },
         }
@@ -192,7 +196,7 @@ impl RpcService {
         &self,
         rfp_id: i32,
         block_id: i64,
-    ) -> Result<VersionedRFP, Status> {
+    ) -> anyhow::Result<VersionedRFP> {
         let result: Result<Data<VersionedRFP>, near_api::errors::QueryError<RpcQueryRequest>> =
             self.contract
                 .call_function("get_rfp", json!({ "rfp_id": rfp_id }))
@@ -206,7 +210,7 @@ impl RpcService {
             Ok(res) => Ok(res.data),
             Err(e) => {
                 eprintln!("Failed to get rfp on block: {:?}", e);
-                Err(Status::InternalServerError)
+                Err(anyhow::anyhow!("Failed to get rfp on block: {:?}", e))
             }
         }
     }

--- a/src/rpc_service.rs
+++ b/src/rpc_service.rs
@@ -91,8 +91,8 @@ impl RpcService {
 
         // Use fastnear first before the archival RPC with super low rate limit
         network.rpc_endpoints = vec![
-            custom_endpoint,
             archival_endpoint,
+            custom_endpoint,
             RPCEndpoint::mainnet().with_retries(3),
         ];
 

--- a/src/rpc_service.rs
+++ b/src/rpc_service.rs
@@ -77,15 +77,23 @@ impl RpcService {
 
         let mut network = NetworkConfig::mainnet();
 
+        let archival_endpoint =
+            RPCEndpoint::new("https://archival-rpc.mainnet.fastnear.com".parse().unwrap())
+                .with_api_key(env.fastnear_api_key.parse().unwrap())
+                .with_retries(3)
+                .with_exponential_backoff(true, 2);
+
         let custom_endpoint =
             RPCEndpoint::new("https://rpc.mainnet.fastnear.com/".parse().unwrap())
-                .with_api_key(env.fastnear_api_key.parse().unwrap());
+                .with_api_key(env.fastnear_api_key.parse().unwrap())
+                .with_retries(5)
+                .with_exponential_backoff(true, 3);
 
         // Use fastnear first before the archival RPC with super low rate limit
         network.rpc_endpoints = vec![
+            archival_endpoint,
             custom_endpoint,
-            // RPCEndpoint::new("https://near.lava.build".parse().unwrap()),
-            RPCEndpoint::mainnet(),
+            RPCEndpoint::mainnet().with_retries(3),
         ];
 
         Self {

--- a/src/rpc_service.rs
+++ b/src/rpc_service.rs
@@ -91,8 +91,8 @@ impl RpcService {
 
         // Use fastnear first before the archival RPC with super low rate limit
         network.rpc_endpoints = vec![
-            archival_endpoint,
             custom_endpoint,
+            archival_endpoint,
             RPCEndpoint::mainnet().with_retries(3),
         ];
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -12,7 +12,6 @@ use devhub_cache_api::{
     timestamp_to_date_string, types::PaginatedResponse,
 };
 use futures::StreamExt;
-use near_sdk::AccountId;
 use serde_json::Value;
 
 mod test_env;
@@ -25,6 +24,7 @@ pub struct Env {
     pub fastnear_api_key: String,
 }
 
+// TODO
 #[rocket::async_test]
 async fn test_proposal_ids_continuous_name_status_matches() {
     use rocket::local::asynchronous::Client;
@@ -234,15 +234,15 @@ async fn test_all_proposals_are_indexed() {
     let mut map = HashMap::new();
     map.insert(
         "devhub.near",
-        "https://devhub-cache-api-rs.fly.dev/proposals",
+        "https://devhub-cache-api-rs-2.fly.dev/proposals",
     );
     map.insert(
         "infrastructure-committee.near",
-        "https://infra-cache-api-rs.fly.dev/proposals",
+        "https://infra-cache-api-rs-2.fly.dev/proposals",
     );
     map.insert(
         "events-committee.near",
-        "https://events-cache-api-rs.fly.dev/proposals",
+        "https://events-cache-api-rs-2.fly.dev/proposals",
     );
 
     for contract_string in contract_strings {
@@ -445,6 +445,9 @@ fn test_custom_error_handler() {
 async fn test_route_test() {
     use rocket::local::asynchronous::Client;
 
+    dotenvy::dotenv().ok();
+    let contract = std::env::var("CONTRACT").unwrap();
+
     let client = Client::tracked(devhub_cache_api::rocket(None))
         .await
         .expect("valid Rocket instance");
@@ -453,6 +456,6 @@ async fn test_route_test() {
     let response = client.get("/test").dispatch().await;
     assert_eq!(
         response.into_string().await.unwrap(),
-        "Welcome to devhub.near"
+        format!("Welcome to {}", contract)
     );
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -6,7 +6,7 @@ use futures::future::join_all;
 use devhub_cache_api::db::db_types::LastUpdatedInfo;
 use devhub_cache_api::entrypoints::proposal::proposal_types::ProposalBodyFields;
 use devhub_cache_api::nearblocks_client::types::BLOCK_HEIGHT_OFFSET;
-use devhub_cache_api::rpc_service::{self, ChangeLogType, RpcService};
+use devhub_cache_api::rpc_service::{ChangeLogType, RpcService};
 use devhub_cache_api::{
     db::db_types::ProposalWithLatestSnapshotView, separate_number_and_text,
     timestamp_to_date_string, types::PaginatedResponse,
@@ -64,7 +64,7 @@ async fn test_proposal_ids_continuous_name_status_matches() {
     let rpc_service = RpcService::new();
 
     // Create a Vec of futures for all blockchain calls
-    let futures = result.records.iter().enumerate().map(|(_ndx, record)| {
+    let futures = result.records.iter().map(|record| {
         let proposal_id = record.proposal_id;
         let rpc_service = rpc_service.clone();
         let record = record.clone();
@@ -122,7 +122,7 @@ async fn test_if_the_last_ten_changed_will_get_indexed() -> Result<(), Box<dyn s
 
     let contract_string: String =
         std::env::var("CONTRACT").unwrap_or_else(|_| "devhub.near".to_string());
-    let contract_account_id: AccountId = contract_string.parse().unwrap();
+    // let contract_account_id: AccountId = contract_string.parse().unwrap();
 
     // Get changelog from the RPC service
     let rpc_service = RpcService::new();


### PR DESCRIPTION
I explaind [here](https://github.com/NEAR-DevHub/ref-sdk-api/pull/14) we had to redeploy the indexer to the new organization of fly.io.

Today I set all the secrets and started re-indexing from the start and noticed that some changes I made while developing the sputnik indexer weren't included here yet. So I made some quick changes to improve the reliability.

- Only update last block if transaction was succesfully indexed.
- Move all fly configurations to other apps (I added -2 in every name for the new organization)
- Added fastnear archival RPC 
- added a continue sync endpoint
- added a max_transactions to fetching the transactions from nearblocks. We don't want to fetch 2000 transactions and run into an RPC error and have to fetch it again. Even better would be te index those transactions from nearblocks.


Devhub can start indexing from a later block
You can set the blockid like this: `/proposals/info/block/113950977`
and continue indexing per 250 transactions: `/proposals/continue_sync/250`